### PR TITLE
Retire le flag `baseurl` du build Jekyll sur GitHub

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/configure-pages@v3
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
       - name: Upload artifact


### PR DESCRIPTION
**À merger après à https://github.com/Scribouilli/scribouilli/pull/137**

## Description 

Dans la PR https://github.com/Scribouilli/scribouilli/pull/137, on [ajoute dans la config l'option `baseurl`](https://github.com/Scribouilli/scribouilli/pull/137/files#diff-cdeeb08eff1aff0ae52bb649fb74be147f225f5038e071276d1cefc8ccee40f4R137). Ça me semble bien de le retirer dans le workflow GitHub par conséquent pour qu'on ait deux flows identiques sur GitHub et GitLab et qu'on ne se pose pas de questions.